### PR TITLE
Update casadi requirement 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         "rtc-tools == 2.6.0a3",
         "pyesdl >= 23.11.1",
         "pandas >= 1.3.1, < 2.0",
-        "casadi == 3.6.3",
+        "casadi == 3.6.4",
     ],
     tests_require=["pytest", "pytest-runner", "numpy"],
     include_package_data=True,


### PR DESCRIPTION
We update the casadi requirement again. First we restricted it as tests would fail going to 3.6.4, however with the new absolute heat description we do no longer have this issue. I propose we do a hard specification on casadi to avoid unwanted pipeline failures in the future.

@FJanssen-TNO @KobusVanRooyen do you agree