### PR TITLE
Speed up problem with summed heat loss ordering and more constraints on stage 2 in grow workflow

### DIFF
--- a/examples/municipality/model/GROW_withATES_Prod_install.esdl
+++ b/examples/municipality/model/GROW_withATES_Prod_install.esdl
@@ -1777,10 +1777,10 @@
         <port xsi:type="esdl:InPort" connectedTo="eb32f4c3-c492-439d-89e8-142ea6882c67" id="6f024397-cf6a-4232-bdb3-e9e4285fed59" carrier="39ec9ed1-30d6-40db-83a4-1bac7b0b3c75" name="In"/>
         <port xsi:type="esdl:OutPort" id="5c089df4-9cb1-4249-8e2b-b46994220f62" connectedTo="95416ff8-70ce-48d9-ae41-cdf234f4408f" carrier="39ec9ed1-30d6-40db-83a4-1bac7b0b3c75_ret" name="Out"/>
         <costInformation xsi:type="esdl:CostInformation" id="f6ab2a6d-41d5-4e10-b917-e9c443151624">
-          <investmentCosts xsi:type="esdl:SingleValue" value="690.0" id="47fd41e1-9017-466e-b6a1-5ea7f776dfa5">
+          <investmentCosts xsi:type="esdl:SingleValue" value="69000.0" id="47fd41e1-9017-466e-b6a1-5ea7f776dfa5">
             <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" id="ff0a7278-91de-4ca4-82a7-25ae9d63e8e1" description="Cost in EUR/m3" perUnit="CUBIC_METRE" physicalQuantity="COST" unit="EURO"/>
           </investmentCosts>
-          <installationCosts xsi:type="esdl:SingleValue" value="300.0" id="cc47852c-c7cc-44b3-abd5-5e14378489e8">
+          <installationCosts xsi:type="esdl:SingleValue" value="600000.0" id="cc47852c-c7cc-44b3-abd5-5e14378489e8">
             <profileQuantityAndUnit xsi:type="esdl:QuantityAndUnitType" physicalQuantity="COST" id="164720ce-b344-482b-8fb2-9fe2938cfde1" description="Cost in EUR" unit="EURO"/>
           </installationCosts>
         </costInformation>

--- a/examples/municipality/src/run_municipality.py
+++ b/examples/municipality/src/run_municipality.py
@@ -1,10 +1,10 @@
-from rtctools_heat_network.workflows import EndScenarioSizingStaged, run_end_scenario_sizing
+from rtctools_heat_network.workflows import EndScenarioSizingStagedHIGHS, run_end_scenario_sizing
 
 if __name__ == "__main__":
     import time
 
     start_time = time.time()
 
-    solution = run_end_scenario_sizing(EndScenarioSizingStaged)
+    solution = run_end_scenario_sizing(EndScenarioSizingStagedHIGHS)
 
     print("Execution time: " + time.strftime("%M:%S", time.gmtime(time.time() - start_time)))

--- a/src/rtctools_heat_network/heat_mixin.py
+++ b/src/rtctools_heat_network/heat_mixin.py
@@ -3023,15 +3023,21 @@ class HeatMixin(_HeadLossMixin, BaseComponentTypeMixin, CollocatedIntegratedOpti
         # These are the constraints to order the heat loss of the pipe classes.
         if not self.heat_network_options()["neglect_pipe_heat_losses"]:
             for pipe, pipe_classes in self.__pipe_topo_pipe_class_heat_loss_ordering_map.items():
-                heat_loss_sym_name = self.__pipe_topo_heat_loss_map[pipe]
-                if pipe in self.hot_pipes and self.has_related_pipe(p):
+                if pipe in self.hot_pipes and self.has_related_pipe(pipe):
+                    heat_loss_sym_name = self.__pipe_topo_heat_loss_map[pipe]
                     heat_loss_sym = self.extra_variable(heat_loss_sym_name, ensemble_member)
                     cold_name = self.__pipe_topo_heat_loss_map[self.hot_to_cold_pipe(pipe)]
                     heat_loss_sym += self.extra_variable(cold_name, ensemble_member)
-                elif pipe in self.hot_pipes and not self.has_related_pipe(p):
+                    heat_losses = [h1 + h2 for h1, h2 in zip(self.__pipe_topo_heat_losses[pipe],
+                                                             self.__pipe_topo_heat_losses[
+                                                                 self.hot_to_cold_pipe(pipe)])]
+                elif pipe in self.hot_pipes and not self.has_related_pipe(pipe):
+                    heat_loss_sym_name = self.__pipe_topo_heat_loss_map[pipe]
                     heat_loss_sym = self.extra_variable(heat_loss_sym_name, ensemble_member)
 
-                heat_losses = self.__pipe_topo_heat_losses[pipe]
+                    heat_losses = self.__pipe_topo_heat_losses[pipe]
+                else: #cold pipe
+                    continue
 
                 big_m = 2.0 * max(heat_losses)
                 for var_name, heat_loss in zip(pipe_classes.values(), heat_losses):

--- a/src/rtctools_heat_network/heat_mixin.py
+++ b/src/rtctools_heat_network/heat_mixin.py
@@ -3282,15 +3282,19 @@ class HeatMixin(_HeadLossMixin, BaseComponentTypeMixin, CollocatedIntegratedOpti
                     heat_loss_sym = self.extra_variable(heat_loss_sym_name, ensemble_member)
                     cold_name = self.__pipe_topo_heat_loss_map[self.hot_to_cold_pipe(pipe)]
                     heat_loss_sym += self.extra_variable(cold_name, ensemble_member)
-                    heat_losses = [h1 + h2 for h1, h2 in zip(self.__pipe_topo_heat_losses[pipe],
-                                                             self.__pipe_topo_heat_losses[
-                                                                 self.hot_to_cold_pipe(pipe)])]
+                    heat_losses = [
+                        h1 + h2
+                        for h1, h2 in zip(
+                            self.__pipe_topo_heat_losses[pipe],
+                            self.__pipe_topo_heat_losses[self.hot_to_cold_pipe(pipe)],
+                        )
+                    ]
                 elif pipe in self.hot_pipes and not self.has_related_pipe(pipe):
                     heat_loss_sym_name = self.__pipe_topo_heat_loss_map[pipe]
                     heat_loss_sym = self.extra_variable(heat_loss_sym_name, ensemble_member)
 
                     heat_losses = self.__pipe_topo_heat_losses[pipe]
-                else: #cold pipe
+                else:  # cold pipe
                     continue
 
                 big_m = 2.0 * max(heat_losses)

--- a/src/rtctools_heat_network/workflows/grow_workflow.py
+++ b/src/rtctools_heat_network/workflows/grow_workflow.py
@@ -579,6 +579,7 @@ def run_end_scenario_sizing(end_scenario_problem_class, staged_pipe_optimization
                 ub = []
                 for i in range(len(t)):
                     r = results[f"{p}__flow_direct_var"][i]
+                    # bound to roughly represent 4km of heat losses in pipes
                     lb.append(
                         r if abs(results[f"{p}.Q"][i] / parameters[f"{p}.area"]) > 2.5e-2 else 0
                     )

--- a/src/rtctools_heat_network/workflows/grow_workflow.py
+++ b/src/rtctools_heat_network/workflows/grow_workflow.py
@@ -565,9 +565,10 @@ def run_end_scenario_sizing(end_scenario_problem_class, staged_pipe_optimization
             *solution.heat_network_components.get("buffer", []),
         ]:
             var_name = f"{asset}_aggregation_count"
-            r = results[var_name][0]
-            if round(r) >= 1:
-                boolean_bounds[var_name] = (r, r)
+            lb = results[var_name][0]
+            ub = solution.bounds()[var_name][1]
+            if round(lb) >= 1:
+                boolean_bounds[var_name] = (lb, ub)
 
         t = solution.times()
         from rtctools.optimization.timeseries import Timeseries

--- a/src/rtctools_heat_network/workflows/grow_workflow.py
+++ b/src/rtctools_heat_network/workflows/grow_workflow.py
@@ -453,6 +453,19 @@ class EndScenarioSizingStaged(EndScenarioSizing):
 
         return options
 
+    def solver_options(self):
+        options = super().solver_options()
+        options["solver"] = "gurobi"
+        gurobi_options = options["gurobi"] = {}
+        if self._stage == 1:
+            gurobi_options["MIPgap"] = 0.005
+        else:
+            gurobi_options["MIPgap"] = 0.02
+        gurobi_options["threads"] = 4
+        gurobi_options["LPWarmStart"] = 2
+
+        return options
+
     def bounds(self):
         bounds = super().bounds()
 
@@ -468,7 +481,10 @@ class EndScenarioSizingStagedHIGHS(EndScenarioSizingStaged):
         options["casadi_solver"] = self._qpsol
         options["solver"] = "highs"
         highs_options = options["highs"] = {}
-        highs_options["mip_rel_gap"] = 0.02
+        if self._stage == 1:
+            highs_options["mip_rel_gap"] = 0.005
+        else:
+            highs_options["mip_rel_gap"] = 0.02
 
         options["gurobi"] = None
 

--- a/src/rtctools_heat_network/workflows/grow_workflow.py
+++ b/src/rtctools_heat_network/workflows/grow_workflow.py
@@ -580,10 +580,10 @@ def run_end_scenario_sizing(end_scenario_problem_class, staged_pipe_optimization
                 for i in range(len(t)):
                     r = results[f"{p}__flow_direct_var"][i]
                     lb.append(
-                        r if abs(results[f"{p}.Q"][i] / parameters[f"{p}.area"]) > 1.0e-2 else 0
+                        r if abs(results[f"{p}.Q"][i] / parameters[f"{p}.area"]) > 2.5e-2 else 0
                     )
                     ub.append(
-                        r if abs(results[f"{p}.Q"][i] / parameters[f"{p}.area"]) > 1.0e-2 else 1
+                        r if abs(results[f"{p}.Q"][i] / parameters[f"{p}.area"]) > 2.5e-2 else 1
                     )
 
                 boolean_bounds[f"{p}__flow_direct_var"] = (Timeseries(t, lb), Timeseries(t, ub))
@@ -593,13 +593,15 @@ def run_end_scenario_sizing(end_scenario_problem_class, staged_pipe_optimization
                 except KeyError:
                     pass
 
-    _ = run_optimization_problem(
+    solution = run_optimization_problem(
         end_scenario_problem_class,
         stage=2,
         boolean_bounds=boolean_bounds,
     )
 
     print("Execution time: " + time.strftime("%M:%S", time.gmtime(time.time() - start_time)))
+
+    return solution
 
 
 @main_decorator

--- a/tests/models/test_case_small_network_ates_buffer_optional_assets/src/run_ates.py
+++ b/tests/models/test_case_small_network_ates_buffer_optional_assets/src/run_ates.py
@@ -151,6 +151,7 @@ class HeatProblem(
 
 if __name__ == "__main__":
     from pathlib import Path
+
     # from rtctools.util import run_optimization_problem
     # from rtctools_heat_network.workflows import EndScenarioSizingHIGHS
     import time

--- a/tests/models/test_case_small_network_ates_buffer_optional_assets/src/run_ates.py
+++ b/tests/models/test_case_small_network_ates_buffer_optional_assets/src/run_ates.py
@@ -154,13 +154,17 @@ if __name__ == "__main__":
     from pathlib import Path
     from rtctools_heat_network.workflows import EndScenarioSizingHIGHS
     import time
+    from rtctools_heat_network.workflows import EndScenarioSizingStaged, run_end_scenario_sizing
 
     start_time = time.time()
     base_folder = Path(__file__).resolve().parent.parent
 
-    solution = run_optimization_problem(EndScenarioSizingHIGHS, base_folder=base_folder)
-    results = solution.extract_results()
-    print(results["Pipe_352c__hn_diameter"])
+    # solution = run_optimization_problem(EndScenarioSizingHIGHS, base_folder=base_folder)
+    # results = solution.extract_results()
+    solution = run_end_scenario_sizing(EndScenarioSizingStaged)
+
+
+    # print(results["Pipe_352c__hn_diameter"])
     # print(results["Pipe_352c__hn_pipe_class_None"])
     a = 1
 

--- a/tests/models/test_case_small_network_ates_buffer_optional_assets/src/run_ates.py
+++ b/tests/models/test_case_small_network_ates_buffer_optional_assets/src/run_ates.py
@@ -8,7 +8,6 @@ from rtctools.optimization.goal_programming_mixin import Goal, GoalProgrammingMi
 from rtctools.optimization.linearized_order_goal_programming_mixin import (
     LinearizedOrderGoalProgrammingMixin,
 )
-from rtctools.util import run_optimization_problem
 
 from rtctools_heat_network.esdl.esdl_mixin import ESDLMixin
 from rtctools_heat_network.heat_mixin import HeatMixin
@@ -152,7 +151,8 @@ class HeatProblem(
 
 if __name__ == "__main__":
     from pathlib import Path
-    from rtctools_heat_network.workflows import EndScenarioSizingHIGHS
+    # from rtctools.util import run_optimization_problem
+    # from rtctools_heat_network.workflows import EndScenarioSizingHIGHS
     import time
     from rtctools_heat_network.workflows import EndScenarioSizingStaged, run_end_scenario_sizing
 
@@ -162,7 +162,6 @@ if __name__ == "__main__":
     # solution = run_optimization_problem(EndScenarioSizingHIGHS, base_folder=base_folder)
     # results = solution.extract_results()
     solution = run_end_scenario_sizing(EndScenarioSizingStaged)
-
 
     # print(results["Pipe_352c__hn_diameter"])
     # print(results["Pipe_352c__hn_pipe_class_None"])


### PR DESCRIPTION
1.  we now create only one heat loss ordering variable which summs both hot and cold pipe if they are related
2. we now constrain more booleans in stage 2 incl placed sources and buffer, flow directions, is disconnected
3. municipality esdl has slightly better scaling now by using larger installation and investment cost for buffers (these numbers are somewhat random)