### PR TITLE
update of pyesdl version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "pyecore",
         "pymoca >= 0.9.0",
         "rtc-tools == 2.6.0a3",
-        "pyesdl >= 23.12",
+        "pyesdl >= 23.12, < 24.0",
         "pandas >= 1.3.1, < 2.0",
         "casadi == 3.6.3",
         "StrEnum == 0.4.15",


### PR DESCRIPTION
To ensure the build uses a pyesdl version <24.0 as in 24 the pyesdl causes a bug with this repo with respect to the profile reading.