### PR TITLE
readthedocs: add a yaml config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.8"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,23 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+  - path: .
+  - requirements: doc/requirements.txt


### PR DESCRIPTION
A config file is now required to build the readthedocs documentation. 
See https://blog.readthedocs.com/migrate-configuration-v2/.