### PR TITLE
Fix read the docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: doc/conf.py
+  configuration: docs/conf.py
 
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,4 +20,4 @@ sphinx:
 python:
   install:
   - path: .
-  - requirements: doc/requirements.txt
+  - requirements: docs/requirements.txt


### PR DESCRIPTION
Corrected yaml file. Able to build the read the docs.
![image](https://github.com/Project-OMOTES/rtc-tools-heat-network/assets/100276887/dd042060-5b84-4a17-82fd-2c1390ccbf3b)
